### PR TITLE
Update Trx DataStore as part of the flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+- Update mongoDB collections used by `CMS SAO` to track entry/draft transactions
+
 ## 0.2.0
 
 - Proccess up to 10 jobs concurrently (can be overriden).

--- a/config.js
+++ b/config.js
@@ -10,6 +10,8 @@ module.exports = {
   queueName: process.env.NESO_WORKER_QUEUE_NAME|| 'neso_queue',
   cmsUrl: process.env.NESO_CMS_URL || 'http://localhost',
   cmsSecret: process.env.NESO_CMS_SECRET || '8e045a51e4b102ea803c06f92841a1fb',
+  entryTrxCollectionName: process.env.NESO_ENTRY_TRX_COL_NAME || 'entry_trx',
+  draftTrxCollectionName: process.env.NESO_DRAFT_TRX_COL_NAME || 'draft_trx',
   workerPollFrequence: process.env.NESO_WORKER_POLL_FREQUENCE || 200,
   workerJobPoolLimit: process.env.NESO_WORKER_JOB_POOL_LIMIT || 10
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const mongodb = require('mongodb')
+const ObjectID = mongodb.ObjectID
 const Worker = require('./worker')
 const {
     EntryProcessor,
@@ -11,25 +12,29 @@ const {
     queueName,
     cmsUrl,
     cmsSecret,
+    entryTrxCollectionName,
+    draftTrxCollectionName,
     workerPollFrequence,
     workerJobPoolLimit,
 } = require('./config')
 
 
-async function proxyProcess(err, payload) {
+async function proxyProcess(err, payload, opts) {
     let processor
 
     switch (payload.kind) {
         case 'entry':
             processor = new EntryProcessor({
                 baseUrl: cmsUrl,
-                aesSecret: cmsSecret
+                aesSecret: cmsSecret,
+                trxUpdater: opts.trxUpdater(entryTrxCollectionName),
             })
             break
         case 'draft':
             processor = new EntryDraftProcessor({
                 baseUrl: cmsUrl,
-                aesSecret: cmsSecret
+                aesSecret: cmsSecret,
+                trxUpdater: opts.trxUpdater(draftTrxCollectionName),
             })
             break
         default:
@@ -48,9 +53,30 @@ const client = new mongodb.MongoClient(uri, {
 })
 
 client.connect().then((client) => {
+
+    let entryUpdate = (collectionName = 'default') => {
+        let col = client.db(dbName).collection(collectionName)
+        return async (id, document) => {
+            if (!document) {
+                return
+            }
+
+            console.log(`Updating ${id} ${JSON.stringify(document)}`)
+            document.updatedAt = new Date()
+
+            return col.updateOne({
+                _id: ObjectID(id)
+            }, {
+                $set: document
+            }).catch(console.error)
+        }
+    }
+
     let worker = new Worker(client, (err, msg) => {
         console.log(`Processing ${msg.id}`)
-        return proxyProcess(err, msg.payload)
+        return proxyProcess(err, msg.payload, {
+            trxUpdater: entryUpdate
+        })
     }, {
         dbName: dbName,
         queueName: queueName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cms-neso",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Async worker that interacts with CMS user interface",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Instead of using any server send communication, Sao and Neso are sharing the same datastore reference for Entry and Draft transactions. In other words Sao acts as a monitor for the afore-
mentioned resources and is Neso in charge of update their state.

Yes, this is violating the good practice of having autonomous datastorages for microservices but I'll do it anyway.